### PR TITLE
Update dependencies on latest Apache NiFi version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 .gradle
 .project
 .settings
+/build/
+
+# IDEA files
+*.iml
+*.ipr
+*.iws

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,13 @@ repositories {
 }
 
 dependencies {
-    compile "org.apache.nifi:nifi-api:0.4.1" 
-    compile "org.apache.nifi:nifi-runtime:0.4.1"  
-    compile "org.apache.logging.log4j:log4j-core:2.4"
-    compile "org.slf4j:slf4j-api:1.7.12"
-    compile "org.slf4j:slf4j-log4j12:1.7.12"
-    compile "org.slf4j:jul-to-slf4j:1.7.12"
+    compile "javax.servlet:servlet-api:3.1.0"
+    compile "org.apache.nifi:nifi-api:1.8.0"
+    compile "org.apache.nifi:nifi-runtime:1.8.0"
+    compile "org.apache.logging.log4j:log4j-core:2.11.1"
+    compile "org.slf4j:slf4j-api:1.7.25"
+    compile "org.slf4j:slf4j-log4j12:1.7.25"
+    compile "org.slf4j:jul-to-slf4j:1.7.25"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
In order to debug the latest NiFi we should update the versions of the
at least nifi-* dependencies as well as introduce a new dependency to
javax.servlet:javax-servlet-api:3.1.0

Logging dependencies were updated even though not strictly required.